### PR TITLE
Fix: Handle string type change and fix issue #3

### DIFF
--- a/Flow.Launcher.Plugin.IPDetails/IpApiResponse.cs
+++ b/Flow.Launcher.Plugin.IPDetails/IpApiResponse.cs
@@ -144,5 +144,5 @@ public class LocationInfo
 
     [JsonPropertyName("is_dst")] public bool IsDst { get; set; }
 
-    [JsonPropertyName("accuracy")] public int Accuracy { get; set; }
+    [JsonPropertyName("accuracy")] public string Accuracy { get; set; }
 }

--- a/Flow.Launcher.Plugin.IPDetails/Main.cs
+++ b/Flow.Launcher.Plugin.IPDetails/Main.cs
@@ -256,14 +256,21 @@ namespace Flow.Launcher.Plugin.IPDetails
 
             if (!File.Exists(_cacheFilePath))
             {
-                // Create an empty cache file
-                File.WriteAllText(_cacheFilePath, "{}");
-
                 return false;
             }
 
-            var cacheData =
-                JsonSerializer.Deserialize<Dictionary<string, CachedIpApiResponse>>(File.ReadAllText(_cacheFilePath));
+            Dictionary<string, CachedIpApiResponse> cacheData;
+            try
+            {
+                cacheData = JsonSerializer.Deserialize<Dictionary<string, CachedIpApiResponse>>(
+                    File.ReadAllText(_cacheFilePath), JsonSerializerOptions);
+            }
+            catch (JsonException)
+            {
+                // Cache file is invalid or uses an outdated model
+                File.Delete(_cacheFilePath);
+                return false;
+            }
 
             if (cacheData == null || !cacheData.TryGetValue(url, out var cachedEntry))
             {
@@ -271,22 +278,27 @@ namespace Flow.Launcher.Plugin.IPDetails
             }
 
             // Remove all expired cache entries
+            var keysToRemove = new List<string>();
             foreach (var (key, value) in cacheData)
             {
                 if (DateTime.UtcNow - value.Timestamp >= CacheExpiration)
                 {
-                    cacheData.Remove(key);
+                    keysToRemove.Add(key);
                 }
+            }
+
+            foreach (var key in keysToRemove)
+            {
+                cacheData.Remove(key);
             }
 
             if (DateTime.UtcNow - cachedEntry.Timestamp < CacheExpiration)
             {
                 cachedResponse = cachedEntry.Response;
-
                 return true;
             }
 
-            File.WriteAllText(_cacheFilePath, JsonSerializer.Serialize(cacheData));
+            File.WriteAllText(_cacheFilePath, JsonSerializer.Serialize(cacheData, JsonSerializerOptions));
 
             return false;
         }
@@ -297,10 +309,15 @@ namespace Flow.Launcher.Plugin.IPDetails
 
             if (File.Exists(_cacheFilePath))
             {
-                cacheData =
-                    JsonSerializer
-                        .Deserialize<Dictionary<string, CachedIpApiResponse>>(File.ReadAllText(_cacheFilePath)) ??
-                    new Dictionary<string, CachedIpApiResponse>();
+                try
+                {
+                    cacheData = JsonSerializer.Deserialize<Dictionary<string, CachedIpApiResponse>>(
+                        File.ReadAllText(_cacheFilePath), JsonSerializerOptions) ?? new Dictionary<string, CachedIpApiResponse>();
+                }
+                catch (JsonException)
+                {
+                    cacheData = new Dictionary<string, CachedIpApiResponse>();
+                }
             }
             else
             {
@@ -313,7 +330,7 @@ namespace Flow.Launcher.Plugin.IPDetails
                 Response = response
             };
 
-            File.WriteAllText(_cacheFilePath, JsonSerializer.Serialize(cacheData));
+            File.WriteAllText(_cacheFilePath, JsonSerializer.Serialize(cacheData, JsonSerializerOptions));
         }
 
         private static bool IsPrivateOrBogonIp(IPAddress ip)


### PR DESCRIPTION
## Description
This PR resolves an issue where the plugin crashes with a JSON deserialization error: `The JSON value could not be converted to System.Int32. Path: $.location.accuracy`. 

The `ipapi.is` API has updated their response structure and now returns a string (e.g., `"MEDIUM"`, `"HIGH"`) for the `location.accuracy` field instead of an integer.

Additionally, this PR addresses edge cases where users might have an outdated cache file on their local machine, which would cause persistent deserialization crashes even after updating the data model. 

## Changes Made
* **Updated Data Model**: Changed the type of the `Accuracy` property in `IpApiResponse.cs` from `int` to `string` to match the current API response.
* **Robust Cache Deserialization**: Wrapped the cache file reading process in `Main.cs` with a `try/catch` block. If a `JsonException` occurs (e.g., due to an outdated cache file using the old integer format), the plugin will now automatically delete the invalid cache file and gracefully fall back to fetching fresh data from the API.
* **Consistent JSON Options**: Ensured that `JsonSerializerOptions` (which includes custom converters like `IsVpnConverter`) are explicitly passed to both `JsonSerializer.Serialize` and `JsonSerializer.Deserialize` when reading/writing the cache file, preventing potential future serialization mismatches.

## Related Issues
* Fixes #3